### PR TITLE
Avoid setting stop signals handler directly in visualizer module

### DIFF
--- a/src/graph_jsp_env/disjunctive_graph_jsp_visualizer.py
+++ b/src/graph_jsp_env/disjunctive_graph_jsp_visualizer.py
@@ -26,10 +26,6 @@ def handler_stop_signals(*_) -> None:
     cv2.destroyAllWindows()
 
 
-signal.signal(signal.SIGINT, handler_stop_signals)
-signal.signal(signal.SIGTERM, handler_stop_signals)
-
-
 class DisjunctiveGraphJspVisualizer:
     """
     this class contains the code for all the different rendering options of a `DisjunctiveGraphJssEnv`,
@@ -213,7 +209,9 @@ class DisjunctiveGraphJspVisualizer:
                  scheduled_color="#DAF7A6", not_scheduled_color="#FFC300", color_job_edge="tab:gray",
                  node_drawing_kwargs=None,
                  edge_drawing_kwargs=None,
-                 critical_path_drawing_kwargs=None):
+                 critical_path_drawing_kwargs=None,
+                 handle_stop_signals=True
+                 ):
         """
         :param dpi:                             parameter for `matplotlib.pyplot.figure`
         :param width:                           parameter for `matplotlib.pyplot.figure`
@@ -245,6 +243,10 @@ class DisjunctiveGraphJspVisualizer:
             "width": 20,
             "alpha": 0.1,
         } if critical_path_drawing_kwargs is None else critical_path_drawing_kwargs
+
+        if handle_stop_signals:
+            signal.signal(signal.SIGINT, handler_stop_signals)
+            signal.signal(signal.SIGTERM, handler_stop_signals)
 
     def graph_rgb_array(self, G: nx.DiGraph) -> np.ndarray:
         """


### PR DESCRIPTION
When using the JSP env with ray.rllib (for ray<2.40), we get an error because of the signals handlers.

So we add an option in `DisjunctiveGraphJspVisualizer.__init__()` to avoid setting it.

That way one can use ray.rllib algorithms as follows:

```python
import numpy as np
import ray
from graph_jsp_env.disjunctive_graph_jsp_env import DisjunctiveGraphJspEnv
from ray.rllib.algorithms import PPO
from ray.tune import register_env

jsp = np.array(
    [
        [
            [0, 1, 2],  # machines for job 0
            [0, 2, 1],  # machines for job 1
            [0, 1, 2],  # machines for job 2
        ],
        [
            [3, 2, 2],  # task durations of job 0
            [2, 1, 4],  # task durations of job 1
            [0, 4, 3],  # task durations of job 2
        ],
    ]
)

register_env(
    "jsp",
    lambda env_config: DisjunctiveGraphJspEnv(
        jps_instance=jsp,
        visualizer_kwargs=dict(handle_stop_signals=False)
    ),
)

ray.init()
algo = PPO(config=PPO.get_default_config().environment("jsp"))
algo.train()

```

Without the option `visualizer_kwargs=dict(handle_stop_signals=False)`, the above code fails wtih ray<2.40.

Note that using action masks would perform better, it needs
- wrapping the environment in another one enriching the mask to the observation
- using a custom model as shown in https://docs.ray.io/en/latest/rllib/rllib-models.html#variable-length-parametric-action-spaces

This solves #4.