### PR TITLE
fix: trailing comma typo in reset() and sort() compatibility with pandas StringArray

### DIFF
--- a/src/graph_jsp_env/disjunctive_graph_jsp_env.py
+++ b/src/graph_jsp_env/disjunctive_graph_jsp_env.py
@@ -555,7 +555,7 @@ class DisjunctiveGraphJspEnv(gym.Env):
         for i in range(1, self.total_tasks_without_dummies + 1):
             node = self.G.nodes[i]
             node["scheduled"] = False
-            node["start_time"] = None,
+            node["start_time"] = None
             node["finish_time"] = None
 
         return self.get_state(), info  # obs, info

--- a/src/graph_jsp_env/disjunctive_graph_jsp_visualizer.py
+++ b/src/graph_jsp_env/disjunctive_graph_jsp_visualizer.py
@@ -114,8 +114,7 @@ class DisjunctiveGraphJspVisualizer:
 
         if len(df) > 0:
             machines = sorted(df['Resource'].unique())
-            jobs = df['Task'].unique()
-            jobs.sort()
+            jobs = sorted(df['Task'].unique())
         else:
             jobs, machines = None, None
 


### PR DESCRIPTION
Fix trailing comma typo in reset() that caused start_time to be stored as (None,) tuple instead of None, and fix jobs.sort() compatibility with pandas StringArray returned by newer versions of pandas. 